### PR TITLE
fix: align Fluent make signatures for Laravel 12

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         stability: [prefer-lowest, prefer-stable]
         laravel: [10.*]
-        php: [8.1, 8.2]
+        php: [8.2]
         include:
           - laravel: 10.*
             testbench: 8.*

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,14 +11,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        laravel: [9.*]
+        laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
-            php: 8.1
+          - laravel: 10.*
+            testbench: 8.*
+            php: 8.2
             larastan: 2.*
-            collision: 6.*
+            collision: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^10.0|^11.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",

--- a/src/Helpers/Action.php
+++ b/src/Helpers/Action.php
@@ -53,8 +53,10 @@ class Action extends Fluent
 
     /**
      * Make a new action instance.
+     *
+     * @param  array|string  $options
      */
-    public static function make(array|string $options = []): static
+    public static function make($options = []): static
     {
         return new static(is_string($options) ? ['innerHTML' => $options] : $options);
     }

--- a/src/Helpers/Column.php
+++ b/src/Helpers/Column.php
@@ -84,8 +84,10 @@ class Column extends Fluent
 
     /**
      * Make a new column instance.
+     *
+     * @param  array|string  $options
      */
-    public static function make(array|string $options = []): static
+    public static function make($options = []): static
     {
         return new static(is_string($options) ? [
             'title' => Str::of($options)->replace('_', ' ')->title()->toString(),

--- a/src/Helpers/TabulatorConfig.php
+++ b/src/Helpers/TabulatorConfig.php
@@ -17,6 +17,7 @@ use FmTod\LaravelTabulator\Concerns\Config\SortConfig;
 use FmTod\LaravelTabulator\TabulatorTable;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
+use Traversable;
 
 /**
  * Tabulator configuration instance.
@@ -234,9 +235,13 @@ class TabulatorConfig extends Fluent
     /**
      * Make a new column instance.
      */
-    public static function make(array $options = []): static
+    public static function make($attributes = []): static
     {
-        return new static($options);
+        return new static(match (true) {
+            $attributes instanceof Traversable => iterator_to_array($attributes),
+            is_array($attributes) => $attributes,
+            default => [$attributes],
+        });
     }
 
     /**

--- a/src/Helpers/TabulatorConfig.php
+++ b/src/Helpers/TabulatorConfig.php
@@ -15,9 +15,9 @@ use FmTod\LaravelTabulator\Concerns\Config\RowConfig;
 use FmTod\LaravelTabulator\Concerns\Config\RowGroupConfig;
 use FmTod\LaravelTabulator\Concerns\Config\SortConfig;
 use FmTod\LaravelTabulator\TabulatorTable;
-use InvalidArgumentException;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use Traversable;
 
 /**

--- a/src/Helpers/TabulatorConfig.php
+++ b/src/Helpers/TabulatorConfig.php
@@ -15,6 +15,7 @@ use FmTod\LaravelTabulator\Concerns\Config\RowConfig;
 use FmTod\LaravelTabulator\Concerns\Config\RowGroupConfig;
 use FmTod\LaravelTabulator\Concerns\Config\SortConfig;
 use FmTod\LaravelTabulator\TabulatorTable;
+use InvalidArgumentException;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 use Traversable;
@@ -240,7 +241,10 @@ class TabulatorConfig extends Fluent
         return new static(match (true) {
             $attributes instanceof Traversable => iterator_to_array($attributes),
             is_array($attributes) => $attributes,
-            default => [$attributes],
+            default => throw new InvalidArgumentException(sprintf(
+                'TabulatorConfig::make expects attributes to be an array or Traversable, %s given.',
+                get_debug_type($attributes)
+            )),
         });
     }
 

--- a/tests/Feature/TabulatorConfigTest.php
+++ b/tests/Feature/TabulatorConfigTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use FmTod\LaravelTabulator\Helpers\TabulatorConfig;
+
+it('throws for invalid attribute types', function () {
+    TabulatorConfig::make('invalid');
+})->throws(\InvalidArgumentException::class, 'TabulatorConfig::make expects attributes to be an array or Traversable, string given.');


### PR DESCRIPTION
## Summary
- update tabulator helper make signatures to match Laravel 12 Fluent expectations
- keep helper behavior unchanged while restoring compatibility with the framework upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded Laravel support to include Laravel 11 and 12
  * Updated CI to run on PHP 8.2 and align tests with Laravel 10

* **Refactor**
  * Factory methods now accept a broader range of input types while preserving previous behavior

* **Tests**
  * Added a test to ensure invalid config input raises a clear error

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FmTod/laravel-tabulator/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->